### PR TITLE
Fixed git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SMS бомбер с приятным веб-интерфейсом.
 2. Установите git для Windows, скачав его [отсюда](https://git-scm.com/download/win).
 3. Клонируйте репозиторий при помощи git и перейдите в папку:
     ```bash
-    git clone https://github.com/crinny/b0mb3r
+    git clone https://github.com/denishnc/b0mb3r
     cd b0mb3r
     ```
 4. Установите все необходимые библиотеки и запустите скрипт:


### PR DESCRIPTION
Since repo owner changed his Github name, the old clone URL was not working anymore.